### PR TITLE
Allow failing build on errors

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -87,6 +87,9 @@ junitResultsDir:: (optional) directory where the results written to in JUnit XML
                   read by many tools including CI environments.
 				  Defaults to `${buildDir}/test-results/htmlchecks/`
 
+failOnErrors:: (optional) if set to "true", the build will fail if any error was found in the checked pages.
+                      Defaults to `false`
+
 checkExternalLinks:: (optional, planned) if set to "true", external references are checked too.
                       Defaults to `false` (currently not implemented)
 
@@ -108,6 +111,9 @@ htmlSanityCheck {
     // where to put results of sanityChecks...
     checkingResultsDir = new File( "$buildDir/report/htmlchecks" )
     checkExternalLinks = false
+
+    // fail build on errors?
+    failOnErrors = true
 }
 ----
 

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     compile group: 'org.jsoup', name: 'jsoup', version: '1.8.2'
 
     testCompile 'com.tngtech.archunit:archunit-junit:0.5.0'
+    testCompile gradleTestKit()
 } // dependencies
 
 

--- a/src/main/groovy/org/aim42/htmlsanitycheck/ChecksRunner.groovy
+++ b/src/main/groovy/org/aim42/htmlsanitycheck/ChecksRunner.groovy
@@ -204,6 +204,8 @@ class ChecksRunner {
 		if (junitResultsDir) {
 			reportCheckingResultsAsJUnitXml(junitResultsDir.absolutePath)			
 		}
+
+        return resultsForAllPages
     }
 
 

--- a/src/test/groovy/org/aim42/htmlsanitycheck/HtmlSanityCheckTaskFunctionalTest.groovy
+++ b/src/test/groovy/org/aim42/htmlsanitycheck/HtmlSanityCheckTaskFunctionalTest.groovy
@@ -1,0 +1,94 @@
+package org.aim42.htmlsanitycheck
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static org.gradle.testkit.runner.TaskOutcome.FAILED
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class HtmlSanityCheckTaskFunctionalTest extends Specification {
+    private final static VALID_HTML = """<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"><html><head></head><body></body><html>"""
+    private final static INVALID_HTML = """<body><span id="id"/><span id="id"/></body> """
+    private final static GRADLE_VERSIONS = ['3.2', '4.6']
+
+    @Rule
+    final TemporaryFolder testProjectDir = new TemporaryFolder()
+    File buildDir
+    File buildFile
+    File htmlFile
+
+    def setup() {
+        buildDir = testProjectDir.newFolder("build")
+        buildFile = testProjectDir.newFile('build.gradle')
+        htmlFile = testProjectDir.newFile("test.html")
+    }
+
+    @Unroll
+    def "can execute htmlSanityCheck task with Gradle version #gradleVersion"() {
+        given:
+        htmlFile << VALID_HTML
+        buildFile << """
+            plugins {
+                id 'org.aim42.htmlsanitycheck'
+            }
+
+            htmlSanityCheck {
+                sourceDir = file( "${htmlFile.parent}" )
+                checkingResultsDir = file( "${buildDir.absolutePath}" )
+                checkExternalLinks = false
+            }
+        """
+
+        when:
+
+        def result = GradleRunner.create()
+                .withGradleVersion(gradleVersion)
+                .withProjectDir(testProjectDir.root)
+                .withPluginClasspath()
+                .withArguments('htmlSanityCheck')
+                .build()
+
+        then:
+        result.task(":htmlSanityCheck").outcome == SUCCESS
+
+        where:
+        gradleVersion << GRADLE_VERSIONS
+    }
+
+    @Unroll
+    def "invalid HTML fails build with failOnErrors=true and Gradle version #gradleVersion"() {
+        given:
+        htmlFile << INVALID_HTML
+        buildFile << """
+            plugins {
+                id 'org.aim42.htmlsanitycheck'
+            }
+
+            htmlSanityCheck {
+                sourceDir = file( "${htmlFile.parent}" )
+                checkingResultsDir = file( "${buildDir.absolutePath}" )
+                checkExternalLinks = false
+                failOnErrors = true
+            }
+        """
+
+        when:
+
+        def result = GradleRunner.create()
+                .withGradleVersion(gradleVersion)
+                .withProjectDir(testProjectDir.root)
+                .withPluginClasspath()
+                .withArguments('htmlSanityCheck')
+                .buildAndFail()
+
+        then:
+        result.task(":htmlSanityCheck").outcome == FAILED
+        result.output.contains("Found 1 error(s) on all checked pages")
+
+        where:
+        gradleVersion << GRADLE_VERSIONS
+    }
+}


### PR DESCRIPTION
This change set introduces the `failOnErrors` configuration flag,
which fails the build if errors were found in any of the checked
pages.

Closes #154